### PR TITLE
Moves dgl-menu game picking to configuration

### DIFF
--- a/config/ssh-config.edn
+++ b/config/ssh-config.edn
@@ -8,6 +8,7 @@
  :ssh-pass ""
  :dgl-login "dumbbot"
  :dgl-pass "tops3cr3t"
+ :dgl-game "3"
  :ttyrec true
  :no-exit false
  :quit-resumed true

--- a/config/ssh-nao-config.edn
+++ b/config/ssh-nao-config.edn
@@ -6,6 +6,7 @@
  :port 23
  :dgl-login "dumbbot"
  :dgl-pass "tops3cr3t"
+ :dgl-game "2"
  :ttyrec true
  :no-exit true
 }

--- a/config/telnet-config.edn
+++ b/config/telnet-config.edn
@@ -6,5 +6,6 @@
  :port 23
  :dgl-login "quitbot"
  :dgl-pass "tops3cr3t"
+ :dgl-game "2"
  :ttyrec true
 }

--- a/javabots/JavaBot/config/javabot-ssh-config.edn
+++ b/javabots/JavaBot/config/javabot-ssh-config.edn
@@ -8,5 +8,6 @@
  :ssh-pass ""
  :dgl-login "quitbot"
  :dgl-pass "tops3cr3t"
+ :dgl-game "3"
  :ttyrec true
 }

--- a/javabots/SimpleBot/config/simplebot-ssh-config.edn
+++ b/javabots/SimpleBot/config/simplebot-ssh-config.edn
@@ -8,5 +8,6 @@
  :ssh-pass ""
  :dgl-login "quitbot"
  :dgl-pass "tops3cr3t"
+ :dgl-game "3"
  :ttyrec true
 }

--- a/javabots/SimpleBot/config/simplebot-telnet-config.edn
+++ b/javabots/SimpleBot/config/simplebot-telnet-config.edn
@@ -6,5 +6,6 @@
  :port 23
  :dgl-login "quitbot"
  :dgl-pass "tops3cr3t"
+ :dgl-game "2"
  :ttyrec true
 }

--- a/src/bothack/bots/dgl_menu.clj
+++ b/src/bothack/bots/dgl_menu.clj
@@ -31,8 +31,7 @@
                           (throw (IllegalStateException. "Failed to login")))
                         (log/info "DGL menubot finished")
                         (send delegator started)
-            ; the n is for acehack.de to select NetHack, for nao it does nothing
-                        (send delegator write "np")))) ; play!
+                        (send delegator write (config-get config :dgl-game))))) ; play!
         pass-prompt (reify RedrawHandler
                       (redraw [this frame]
                         (when (user-prompt? frame)


### PR DESCRIPTION
This adds dgl-game to the configurations and uses that to decide how to pick the correct variant from the menu.

Both nao and ascension.run (former nethack.dank.ninja (former nethack.xd.cm (former acehack.de))) have moved nethack. asc uses 3 for 343-nao and nao uses 2.